### PR TITLE
Transition to mailchimp

### DIFF
--- a/components/MailchimpForm.vue
+++ b/components/MailchimpForm.vue
@@ -1,0 +1,149 @@
+<template>
+  <div class="card timeline-event status-card">
+    <div class="card-content">
+      <div class="status">
+        <h3>
+          TechLabs Berlin Newsletter
+        </h3>
+        <p>
+          Stay in the loop and get notifications about upcoming events,
+          workshops, new application dates, partnership opportunities, and more.
+        </p>
+        <div class="form has-text-left">
+          <div class="field">
+            <label class="label">Name</label>
+            <div class="control">
+              <input
+                v-model="form.name"
+                class="input is-medium"
+                type="text"
+                placeholder="Enter your name"
+                :disabled="loading"
+              />
+            </div>
+          </div>
+          <div class="field">
+            <label class="label">Email</label>
+            <div class="control">
+              <input
+                v-model="form.email"
+                class="input is-medium"
+                :class="{ 'is-danger': errorEmail }"
+                type="email"
+                placeholder="Enter your email"
+                :disabled="loading"
+              />
+            </div>
+            <p v-if="errorEmail" class="help is-danger">
+              This email is invalid
+            </p>
+          </div>
+          <div class="field">
+            <div class="control">
+              <label class="checkbox">
+                <input
+                  v-model="form.consent"
+                  type="checkbox"
+                  :disabled="loading"
+                />
+                I agree to subscribe to the newsletter and receive emails from
+                TechLabs Berlin. I can unsubscribe at any time.
+              </label>
+            </div>
+            <p v-if="errorConsent" class="help is-danger">
+              You need to agree, otherwise we cannot add you to our list.
+            </p>
+          </div>
+          <div class="field is-grouped">
+            <div class="control">
+              <button
+                class="button is-link"
+                :class="{ 'is-loading': loading }"
+                @click="checkForm"
+              >
+                Subscribe
+              </button>
+            </div>
+            <div class="control">
+              <button
+                class="button is-text"
+                :disabled="loading"
+                @click="$router.push('/')"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+const SIGNUP_URL =
+  'https://a696oel4ti.execute-api.eu-central-1.amazonaws.com/dev/add-to-list'
+export default {
+  name: 'MailchimpForm',
+  data() {
+    return {
+      form: {
+        email: '',
+        name: '',
+        consent: true
+      },
+      errorEmail: false,
+      errorConsent: false,
+      loading: false
+    }
+  },
+  methods: {
+    async submit(email, name) {
+      this.loading = true
+      const data = {
+        email,
+        name
+      }
+      try {
+        const response = await this.$axios.$post(SIGNUP_URL, data, {
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        })
+        console.log('SUCCESS')
+        console.log(response)
+        this.$emit('success')
+      } catch (e) {
+        console.log('ERROR')
+        console.error(e)
+        this.$emit('failure')
+      } finally {
+        this.loading = false
+      }
+    },
+    checkForm(e) {
+      this.errorConsent = !this.form.consent
+      this.errorEmail = false
+      if (!this.form.email || !this.validEmail(this.form.email)) {
+        this.errorEmail = true
+      }
+      if (!this.errorConsent && !this.errorEmail) {
+        this.submit(this.form.email, this.form.name)
+      }
+      e.preventDefault()
+    },
+    validEmail(email) {
+      const re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+      return re.test(email)
+    }
+  }
+}
+</script>
+
+<style lang="sass">
+.form
+  max-width: 24rem;
+  margin: 0 auto 2rem auto;
+.status p
+  line-height: 1.5;
+</style>

--- a/components/MailchimpForm.vue
+++ b/components/MailchimpForm.vue
@@ -57,7 +57,7 @@
           <div class="field is-grouped">
             <div class="control">
               <button
-                class="button is-link"
+                class="techlabs-button"
                 :class="{ 'is-loading': loading }"
                 @click="checkForm"
               >

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -48,8 +48,10 @@ export default {
     '@nuxtjs/pwa',
     // Doc: https://github.com/nuxt-community/dotenv-module
     '@nuxtjs/dotenv',
-    '@nuxtjs/style-resources'
+    '@nuxtjs/style-resources',
+    '@nuxtjs/axios'
   ],
+  axios: {},
   /*
    ** Build configuration
    */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -51,7 +51,15 @@ export default {
     '@nuxtjs/style-resources',
     '@nuxtjs/axios'
   ],
-  axios: {},
+  axios: {
+    // headers: {
+    //   'Access-Control-Allow-Headers': 'Content-Type',
+    //   'Access-Control-Allow-Origin': '*',
+    //   'Access-Control-Allow-Methods': 'GET,HEAD,OPTIONS,POST',
+    //   'Access-Control-Allow-Headers':
+    //     'Access-Control-Allow-Origin, Access-Control-Allow-Headers, Origin,Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers'
+    // }
+  },
   /*
    ** Build configuration
    */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,6 +1721,30 @@
         }
       }
     },
+    "@nuxtjs/axios": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/axios/-/axios-5.12.2.tgz",
+      "integrity": "sha512-MKSuwHRgLTw1tMS1mDf+7XIvQLvF8GlK3rtuJY4lNmZVxYiBYhG3Nd6OrtH07fljNmvL7/JIUzk+1o/tVS6Pkg==",
+      "requires": {
+        "@nuxtjs/proxy": "^2.0.1",
+        "axios": "^0.20.0",
+        "axios-retry": "^3.1.8",
+        "consola": "^2.15.0",
+        "defu": "^3.1.0"
+      },
+      "dependencies": {
+        "consola": {
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/consola/-/consola-2.15.0.tgz",
+          "integrity": "sha512-vlcSGgdYS26mPf7qNi+dCisbhiyDnrN1zaRbw3CSuc2wGOMEGGPsp46PdRG5gqXwgtJfjxDkxRNAgRPr1B77vQ=="
+        },
+        "defu": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/defu/-/defu-3.1.0.tgz",
+          "integrity": "sha512-pc7vS4wbYFtsRL+OaLHKD72VcpOz9eYgzZeoLz9pCs+R8htyPdZnD1CxKP9ttZuT90CLPYFTSaTyc3/7v4gG9A=="
+        }
+      }
+    },
     "@nuxtjs/bulma": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@nuxtjs/bulma/-/bulma-1.2.7.tgz",
@@ -1780,6 +1804,15 @@
       "integrity": "sha512-wQViakFeEz21cz+WsRuJ+uKoxjmzT8w2CRr1FrzjZn8K4R4jqKWT7qP96YnxFHIR1/YErP+P22MkzNzawMNcUQ==",
       "requires": {
         "@nuxtjs/pwa-utils": "3.0.0-beta.16"
+      }
+    },
+    "@nuxtjs/proxy": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/proxy/-/proxy-2.0.1.tgz",
+      "integrity": "sha512-RVZ6iYeAuWteot9oer3vTDCOEiTwg37Mqf6yy8vPD0QQaw4z3ykgM++MzfUl85jM14+qNnODZj5EATRoCY009Q==",
+      "requires": {
+        "consola": "^2.11.3",
+        "http-proxy-middleware": "^1.0.4"
       }
     },
     "@nuxtjs/pwa": {
@@ -1935,6 +1968,14 @@
         "@types/node": "*"
       }
     },
+    "@types/http-proxy": {
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.4.tgz",
+      "integrity": "sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1975,8 +2016,7 @@
     "@types/node": {
       "version": "13.11.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
-      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==",
-      "dev": true
+      "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2823,6 +2863,22 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
+    "axios-retry": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.9.tgz",
+      "integrity": "sha512-NFCoNIHq8lYkJa6ku4m+V1837TP6lCa7n79Iuf8/AqATAHYB0ISaAS1eyIenDOfHOLtym34W65Sjke2xjg2fsA==",
+      "requires": {
+        "is-retry-allowed": "^1.1.0"
+      }
     },
     "babel-eslint": {
       "version": "10.1.0",
@@ -6002,6 +6058,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "events": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
@@ -6539,6 +6600,11 @@
           }
         }
       }
+    },
+    "follow-redirects": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
+      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -7876,6 +7942,73 @@
         }
       }
     },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.0.5.tgz",
+      "integrity": "sha512-CKzML7u4RdGob8wuKI//H8Ein6wNTEQR7yjVEzPbhBLGdOfkfvgTnp2HLnniKBDP9QW4eG10/724iTWLBeER3g==",
+      "requires": {
+        "@types/http-proxy": "^1.17.4",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.19",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -8565,6 +8698,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+    },
+    "is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@creativebulma/bulma-tooltip": "^1.0.2",
+    "@nuxtjs/axios": "^5.12.2",
     "@nuxtjs/bulma": "^1.2.1",
     "@nuxtjs/dotenv": "^1.4.0",
     "@nuxtjs/onesignal": "^3.0.0-beta.16",

--- a/pages/newsletter.vue
+++ b/pages/newsletter.vue
@@ -1,15 +1,64 @@
 <template>
-  <div class="signup-wrapper">
-    <iframe
-      class="signup mj-w-res-iframe"
-      frameborder="0"
-      scrolling="no"
-      marginheight="0"
-      marginwidth="0"
-      src="https://app.mailjet.com/widget/iframe/5567/qAw"
-    ></iframe>
+  <div>
+    <!-- SHOW SUCCESS MSG  -->
+    <div v-if="status === 'success'" class="card timeline-event status-card">
+      <div class="card-content">
+        <div class="status">
+          <h3>Done!</h3>
+          <p>
+            Thank you for the support and we'll be in touch :)
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- SHOW FAIL, TRY AGAIN  -->
+    <div
+      v-else-if="status === 'failure'"
+      class="card timeline-event status-card"
+    >
+      <div class="card-content">
+        <div class="status">
+          <h3>Ooops...</h3>
+          <p>
+            ... something went wrong! Wanna try again?
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- SHOW SUBSCRIPTION FORM -->
+    <div v-else>
+      <!-- <iframe
+        class="signup mj-w-res-iframe"
+        frameborder="0"
+        scrolling="no"
+        marginheight="0"
+        marginwidth="0"
+        src="https://app.mailjet.com/widget/iframe/5567/qAw"
+      ></iframe> -->
+      <MailchimpForm
+        @success="status = 'success'"
+        @failure="status = 'failure'"
+      />
+    </div>
   </div>
 </template>
+
+<script>
+import MailchimpForm from '~/components/MailchimpForm'
+export default {
+  name: 'PageNewsletter',
+  components: {
+    MailchimpForm
+  },
+  data() {
+    return {
+      status: this.$route.query.status
+    }
+  }
+}
+</script>
 
 <style lang="sass">
 .signup-wrapper
@@ -20,4 +69,7 @@
 .signup
   width: 100%
   height: 450px
+
+.status-card
+  margin-top: 2rem
 </style>


### PR DESCRIPTION
Refactored the newsletter section to work with our Mailchimp list. 

## Newsletter page

The newsletter page consists of 3 states: default, showing the subscriptions form; success, when the user subscribes successfully; and failure, when there is an error.

<table>
<tr>
<td>
<img width="858" alt="Default newsletter subscribe page" src="https://user-images.githubusercontent.com/5139870/93719243-73c71000-fb81-11ea-913b-15e6911400ad.png">
</td><td>
<img width="858" alt="Success newsletter page" src="https://user-images.githubusercontent.com/5139870/93719244-76c20080-fb81-11ea-840c-ece69ddf2768.png">
</td><td>
<img width="858" alt="Failurew newsletter page" src="https://user-images.githubusercontent.com/5139870/93719245-76c20080-fb81-11ea-9de7-97fc6dd0bf2e.png">
</td></tr></table>

## Subscription endpoints

As a provisory solution, there are 2 AWS Lambda functions controlling the subscription and opt-in flows. 

- https://a696oel4ti.execute-api.eu-central-1.amazonaws.com/dev/add-to-list adds an email to list provided as a JSON body with "name" and "email" as properties → this is called from the form in the Radar

- https://a696oel4ti.execute-api.eu-central-1.amazonaws.com/dev/opt-in?email=xxx which adds the proper tags to those clicking on the link from the Opt-In newsletter (called only from the newsletter link)

## Issues

- The Lambda functions work well, but we could think about a simpler workflow in the future, and also porting the functions to a TechLabs AWS account. 
- The Failure page still does not recognize what failed and where did the user come from. Failure from subscribing and opting-in both display the same error. 
