### PR TITLE
Develop

### DIFF
--- a/content/milestones.yaml
+++ b/content/milestones.yaml
@@ -10,12 +10,13 @@
     This is intentional and ensures that we can build a community of very smart and motivated learners.
     In that way you can be sure that your learning experience will be awesome and that you'll all have a great time.
     On the other hand, it also means you'll have to invest 20 to 30 minutes. But it'll be worth it, we promise!
-  todos:
-    - name: Submit Your Application
-      resources:
-        - title: Application Form
-          type: Application
-          url: https://techlabsorg.typeform.com/to/auo2IeMv
+  # todos:
+  #   - name: Submit Your Application
+  #     resources:
+  #       - title: Application Form
+  #         type: Application
+  #         url: https://techlabsorg.typeform.com/to/auo2IeMv
+
 # - slug: register
 #   name: Register for Winter Term 2020/21
 #   date: '2020-10-13T20:30:00+02:00'

--- a/content/status.yaml
+++ b/content/status.yaml
@@ -1,6 +1,6 @@
 ---
 text: |
   TechLabs Berlin WS20/21 is about to start.<br/><br/>
-  <strong>The Application Phase is open!</strong><br>Fill our and submit the <span class="highlighted"><a href="https://bln.techlabs.org/APPLY">Application Form</a></span> until September 28th.</br></br>
-  The semester Kick Off will take place on October 12th.
+  <strong>We just closed the Applications Phase with almost 400 applicants!</strong> <br>
+  In the next days, we'll select the participants for the next term, and get everyone ready for the semester Kick Off on October 12th.
 links: []


### PR DESCRIPTION
Updated status and removed the todo from the registration milestone (because it shows as active up to 3 days after the closing date...)

I was wondering, though, if we should just "reset" the radar and only add semester-related topics from now on, starting with the onboarding next week. This way we do not "pollute" the timeline with extra, unnecessary weeks....