### PR TITLE
feat: implement home page announcement

### DIFF
--- a/content-bln/announcement.yaml
+++ b/content-bln/announcement.yaml
@@ -1,0 +1,6 @@
+---
+body: |
+  We just finished our **Summer Term 21** with incredible results. We'll post soon the recording of the final event on YouTube.
+
+  And if you want to know more about the upcoming **Winter Term 21/22**, do [subscribe to our newsletter](https://bln.techlabs.org/newsletter). We should announce dates soon!
+publish: true

--- a/content-bln/events/final-event.yaml
+++ b/content-bln/events/final-event.yaml
@@ -19,7 +19,7 @@ meetings:
     url: https://www.wonder.me/r?id=8be41e17-ee7a-450b-8ff3-444a308b4ae4
 forms: []
 resources: []
-  # - title: 'Recording'
-  #   description: The recording of the Final Event
-  #   type: video
-  #   url: https://drive.google.com/file/d/1-AMscTRuXtSe2xJQwmM9w0xLK7oUYsd6/view?usp=sharing
+  - title: 'Recording'
+    description: The recording of the Final Event
+    type: video
+    url:

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,6 +14,7 @@ export default defineComponent({
     const events = ref()
     const timeline = ref()
     const milestones = ref()
+    const announcement = ref()
     const isPublic = ref(process.env.SCOPE === 'public')
     useFetch(async () => {
       if (isPublic.value) {
@@ -30,6 +31,7 @@ export default defineComponent({
           .sortBy('deadline')
           .fetch()
       }
+      announcement.value = await $content('announcement').fetch()
     })
 
     return {
@@ -37,6 +39,7 @@ export default defineComponent({
       timeline,
       milestones,
       isPublic,
+      announcement,
     }
   },
   head: {},
@@ -66,12 +69,14 @@ export default defineComponent({
             <Events :events="events" :milestones="milestones" />
           </ClientOnly>
         </div>
-        <div v-else>
+        <div v-if="announcement && announcement.publish">
           <WrapperContentBox>
-            <p class="prose text-center">
-              We are preparing the next term for you.<br />Stay tuned.
-            </p></WrapperContentBox
-          >
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div
+              class="prose text-center"
+              v-html="$md.render(announcement.body)"
+            />
+          </WrapperContentBox>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The PR implements a new item called `announcement` which is published up-front on the timeline, in case there are no current or future events to show. 

![image](https://user-images.githubusercontent.com/5139870/126034726-a0d7b64b-11b9-48d5-8585-0d68d36a8a09.png)

The announcement is controlled by the file `content-bln/announcement.yaml` and its property `publish: true`