### PR TITLE
avoid error when no current event exists

### DIFF
--- a/components/Events.vue
+++ b/components/Events.vue
@@ -26,7 +26,7 @@
     </div>
 
     <!-- CURRENT EVENT  -->
-    <div class="mb-8">
+    <div class="mb-8" v-if="currentEvent">
       <ClientOnly>
         <EventListItem
           :tl-event="currentEvent"


### PR DESCRIPTION
The v-if condition here makes sure currentEvent exists. 
It took me a while to realize that currentEvent is undefined because there's no future events.
If the data from the yaml is correct it wouldn't have happened. 
Anyway it's good to have it like that for future adopters :)